### PR TITLE
mv bug in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ if [ -f "/data/phpextfile/extension.sh" ]; then
 
     sh /data/phpextfile/extension.sh
 
-    mv -rf /data/phpextfile/extension.sh /data/phpextfile/extension_back.sh
+    mv -f /data/phpextfile/extension.sh /data/phpextfile/extension_back.sh
 
     #Clean OS
     yum remove -y gcc \


### PR DESCRIPTION
```
mv: invalid option -- 'r'
Try 'mv --help' for more information.
```
When I installed the extension, the file `extension.sh` always there.
Just see my pr's File's Changed.